### PR TITLE
fix: chart release demote version due to upstream bug

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -117,9 +117,13 @@ jobs:
           set -euo pipefail
           helm package -u --destination=.cr-release-packages --app-version="${{ needs.semantic-release.outputs.tag }}" --version=${{ needs.semantic-release.outputs.version }} charts/${{ github.event.repository.name }}
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
+        # Pinned to v1.5.0: v1.6.0+ has a regression where cr.sh crashes with
+        # "latest_tag: unbound variable" when skip_packaging is true, because
+        # latest_tag is only ever assigned in the skip_packaging=false branch
+        # but is read unconditionally afterward. See:
+        # https://github.com/helm/chart-releaser-action/issues/171
+        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           skip_packaging: "true"
-          skip_existing: "true"


### PR DESCRIPTION
---
Thanks for the PR!

This PR deploys to namespace `245e18-dev` as release `nr-oracle-service-129`.

Once merged, code will be promoted via the [Merge Workflow](https://github.com/bcgov/nr-oracle-service/actions/workflows/merge.yml).